### PR TITLE
Use UUIDs when registering dynamic textures

### DIFF
--- a/src/main/java/hibiii/kappa/Provider.java
+++ b/src/main/java/hibiii/kappa/Provider.java
@@ -28,7 +28,7 @@ public final class Provider {
 				URL url = new URL("http://s.optifine.net/capes/" + player.getName() + ".png");
 				NativeImage tex = uncrop(NativeImage.read(url.openStream()));
 				NativeImageBackedTexture nIBT = new NativeImageBackedTexture(tex);
-				Identifier id = MinecraftClient.getInstance().getTextureManager().registerDynamicTexture("kappa" + player.getName().toLowerCase(), nIBT);
+				Identifier id = MinecraftClient.getInstance().getTextureManager().registerDynamicTexture("kappa" + player.getId().toString().replace("-", ""), nIBT);
 				capes.put(player.getName(), id);
 				callback.onTexAvail(id);
 			}


### PR DESCRIPTION
Previously used player names... Fixes #4 (see issue for details)