### PR TITLE
Use HTTPS for cape downloads instead of HTTP

### DIFF
--- a/src/main/java/hibiii/kappa/Provider.java
+++ b/src/main/java/hibiii/kappa/Provider.java
@@ -25,7 +25,7 @@ public final class Provider {
 	public static void loadCape(GameProfile player, CapeTextureAvailableCallback callback) {
 		Runnable runnable = () -> {
 			try {
-				URL url = new URL("http://s.optifine.net/capes/" + player.getName() + ".png");
+				URL url = new URL("https://optifine.net/capes/" + player.getName() + ".png");
 				NativeImage tex = uncrop(NativeImage.read(url.openStream()));
 				NativeImageBackedTexture nIBT = new NativeImageBackedTexture(tex);
 				Identifier id = MinecraftClient.getInstance().getTextureManager().registerDynamicTexture("kappa" + player.getName().toLowerCase(), nIBT);


### PR DESCRIPTION
HTTPS is preferred over HTTP for [a few reasons](https://doesmysiteneedhttps.com/), and there's [a way to download OptiFine capes via HTTPS](https://github.com/sp614x/optifine/issues/4597#issuecomment-674573896) (`https://optifine.com/cape/<username>.png` instead of `http://s.optifine.net/capes/<username>.png`) so it should probably be used instead.

Not sure if there was a specific reason for not using HTTPS here or if you just didn't know about it... It's probably the latter, I didn't even know about it until earlier today.