### PR TITLE
Fix cape server usage

### DIFF
--- a/src/main/java/hibiii/kappa/Provider.java
+++ b/src/main/java/hibiii/kappa/Provider.java
@@ -28,9 +28,7 @@ public final class Provider {
 				callback.onTexAvail(existingCape);
 				return;
 			}
-			if(!Provider.tryUrl(player, callback, "https://optifine.net/capes/" + player.getName() + ".png")) {
-				Provider.tryUrl(player, callback, "http://s.optifine.net/capes/" + player.getName() + ".png");
-			}
+			Provider.tryUrl(player, callback, "http://s.optifine.net/capes/" + player.getName() + ".png")
 		};
 		Util.getMainWorkerExecutor().execute(runnable);
 	}


### PR DESCRIPTION
OptiFine's cape server address is `http://s.optifine.net/`.

If a player with this mod joins a large server and makes many failed requests to the optifine.net page, they may be blocked from connecting or marked malicious. In addition, these requests are far slower, and will cause visible pop-in for capes.

Yes, this removes a backup, however clients are NOT SUPPOSED TO pull from the `https://optifine.net/capes/` path. We have had problems with this before. `http://s.optifine.net/capes/` is the only path that should be used for pulling user cape data.